### PR TITLE
Update init_colors()

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -73,8 +73,8 @@ def init_display():
 
 #! Define custom colors
 def init_colors():
-	curses.init_pair(7, 255, -1)
-
+	for i in range(0, curses.COLORS):
+        	curses.init_pair(i + 1, i, -1)
 
 #! Interrupt signal handler
 def signal_handler(signal, frame):


### PR DESCRIPTION
I had issues on xterm giving "_curses.error: init_pair() returned ERR"  that did not support 256 colors. 

This is a fast way to init all pairs using the default background available for the terminal. I would suggest you stay between pairs 0 and  8  as some terminals don't support 256 colors.